### PR TITLE
bitsToInt optimization

### DIFF
--- a/wave/reader.go
+++ b/wave/reader.go
@@ -1,7 +1,6 @@
 package wave
 
 import (
-	"bytes"
 	"encoding/binary"
 	"io"
 	"io/ioutil"
@@ -224,13 +223,7 @@ func readHeader(b []byte) WaveHeader {
 	}
 
 	chunkSize := b[4:8]
-	var size uint32
-	buf := bytes.NewReader(chunkSize)
-	err := binary.Read(buf, binary.LittleEndian, &size)
-	if err != nil {
-		panic(err)
-	}
-	hdr.ChunkSize = int(size) // easier to work with ints
+	hdr.ChunkSize = bits32ToInt(chunkSize) // easier to work with ints
 
 	format := b[8:12]
 	if string(format) != "WAVE" {

--- a/wave/reader.go
+++ b/wave/reader.go
@@ -94,48 +94,22 @@ func bitsToFloat(b []byte) float64 {
 }
 
 func bits16ToInt(b []byte) int {
-	if len(b) != 2 {
-		panic("Expected size 4!")
-	}
-	var payload int16
-	buf := bytes.NewReader(b)
-	err := binary.Read(buf, binary.LittleEndian, &payload)
-	if err != nil {
-		// TODO: make safe
-		panic(err)
-	}
-	return int(payload) // easier to work with ints
+	_ = b[1]
+	out := (int32(b[1]) << 8) | int32(b[0])
+	return int(out)
 }
 
 func bits24ToInt(b []byte) int {
-	if len(b) != 3 {
-		panic("Expected size 3!")
-	}
-	// add some padding to turn a 24-bit integer into a 32-bit integer
-	b = append([]byte{0x00}, b...)
-	var payload int32
-	buf := bytes.NewReader(b)
-	err := binary.Read(buf, binary.LittleEndian, &payload)
-	if err != nil {
-		// TODO: make safe
-		panic(err)
-	}
-	return int(payload) // easier to work with ints
+	_ = b[2]
+	out := (int32(b[2]) << 24) | (int32(b[1]) << 16) | (int32(b[0]) << 8)
+	return int(out)
 }
 
 // turn a 32-bit byte array into an int
 func bits32ToInt(b []byte) int {
-	if len(b) != 4 {
-		panic("Expected size 4!")
-	}
-	var payload int32
-	buf := bytes.NewReader(b)
-	err := binary.Read(buf, binary.LittleEndian, &payload)
-	if err != nil {
-		// TODO: make safe
-		panic(err)
-	}
-	return int(payload) // easier to work with ints
+	_ = b[3]
+	out := (int32(b[3]) << 24) | (int32(b[2]) << 16) | (int32(b[1]) << 8) | int32(b[0])
+	return int(out)
 }
 
 func readData(b []byte, wfmt WaveFmt) WaveData {


### PR DESCRIPTION
Creating a new bytes reader with each function call is inefficient as it requires a lot of allocations and performs a lot of operations.
The needed numeric types can be retrieved simply by utilizing bitwise operations.
This approach is good in performance and the code looks simpler and cleaner.

I ran benchmarks on the `Bits24ToIntReader` function and the provided optimized.
Here are my results:
```go
goos: windows
goarch: amd64
pkg: bitsToInt
cpu: 12th Gen Intel(R) Core(TM) i7-12650H
BenchmarkReader-16       2183080               522.5 ns/op           576 B/op         36 allocs/op
BenchmarkBitwise-16     430430271                2.823 ns/op           0 B/op          0 allocs/op
BenchmarkCast-16        450972691                2.645 ns/op           0 B/op          0 allocs/op
```

And here are the functions that I benchmarked:
- Original, with the use of `bytes.NewReader`
```go
func Bits24ToIntReader(b []byte) int {
	if len(b) != 3 {
		panic("Expected size 3!")
	}
	// add some padding to turn a 24-bit integer into a 32-bit integer
	b = append([]byte{0x00}, b...)
	var payload int32
	buf := bytes.NewReader(b)
	err := binary.Read(buf, binary.LittleEndian, &payload)
	if err != nil {
		// TODO: make safe
		panic(err)
	}
	return int(payload) // easier to work with ints
}
```

- Bitwise operations, `shift` and `or`
```go
func Bits24ToIntBitwise(b []byte) int {
	_ = b[2]
	out := (int32(b[2]) << 24) | (int32(b[1]) << 16) | (int32(b[0]) << 8)
	return int(out)
}
```

- Unsafe cast (but should be safe since we check whether the sufficient number of elements is present, right?)
```go
func Bits24ToIntCast(b []byte) int {
	_ = b[2]
	out := *(*uint32)(unsafe.Pointer(&b[0])) << 8
	return int(out)
}
```